### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/9bd4d535-8cb7-4d85-804c-52ee47dccb00/ccba1d44-2398-4721-9d9c-29ddff53a2fe/_apis/work/boardbadge/fb00ac91-8fe4-4208-9730-c6eb8ec9d3de)](https://dev.azure.com/aiw-devops/9bd4d535-8cb7-4d85-804c-52ee47dccb00/_boards/board/t/ccba1d44-2398-4721-9d9c-29ddff53a2fe/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1322](https://dev.azure.com/aiw-devops/9bd4d535-8cb7-4d85-804c-52ee47dccb00/_workitems/edit/1322). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.